### PR TITLE
1.1 Patch from gitlab

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -20,6 +20,16 @@
     "license": "BSD-2-Clause",
     "changelogHistory": [
         {
+            "date": "9/1/20",
+            "version": "1.1.0",
+            "notes": [
+                {
+                    "description": "Make connString detection automatic and fix FabricConnectionState related bugs",
+                    "review_uri": "https://gitlab.eng.vmware.com/bifrost/typescript/merge_requests/108"
+                }
+            ]
+        },
+        {
             "date": "5/27/20",
             "version": "1.0.0",
             "notes": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": false,
   "license": "BSD-2-Clause",
   "repository": "git@github.com:vmware/transport.git",

--- a/src/bridge/stomp.client.ts
+++ b/src/bridge/stomp.client.ts
@@ -273,9 +273,11 @@ export class StompClient implements EventBusEnabled {
         this.currentConnectionState = ConnectionState.Disconnected;
         // switch connection state to error for fabric consumers.
         if (this.bus) {
+            const connString: string = GeneralUtil.getFabricConnectionString(this._config.host, this._config.port, this._config.endpoint);
             this.log.debug('Informing Fabric subscribers that the connection has failed via store.', this.getName());
-            this.bus.stores.createStore(Stores.FabricConnection)
-                .put(FabricConnectionStoreKey.State, FabricConnectionState.Failed, FabricConnectionState.Failed);
+            this.bus.fabric
+                .getConnectionStateStore(connString)
+                .put(connString, FabricConnectionState.Failed, FabricConnectionState.Failed);
         }
 
         this.log.error('Error with WebSocket, Connection Failed', this.getName());

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -18,7 +18,7 @@ import { FabricApi } from './fabric.api';
 import { BrokerConnector } from './bridge';
 
 // current version
-const version = '1.0.0';
+const version = '1.1.0';
 
 export type ChannelName = string;
 export type SentFrom = string;
@@ -434,7 +434,7 @@ export abstract class EventBus {
      * will be transmitted to the remote destinations.
      * @param {ChannelName} channelName name of the channel
      * @param {brokerIdentity} broker's host, port and endpoint used as its identity.
-     *        use BusUtil.getFabricConnectionString() to create one.
+     *        use GeneralUtil.getFabricConnectionString() to create one.
      * @param {isPrivate} whether the channel is a broadcast or a private channel
      */
     abstract markChannelAsGalactic(channelName: ChannelName, brokerIdentity?: string, isPrivate?: boolean): void;
@@ -450,7 +450,7 @@ export abstract class EventBus {
      * be sent to local destinations and will NOT be sent to remote destinations.
      * @param {ChannelName} channelName name of the channel
      * @param {brokerIdentity} broker's host, port and endpoint used as its identity.
-     *        use BusUtil.getFabricConnectionString() to create one.
+     *        use GeneralUtil.getFabricConnectionString() to create one.
      */
     abstract markChannelAsLocal(channelName: ChannelName, brokerIdentity?: string): void;
 

--- a/src/bus/bus.ts
+++ b/src/bus/bus.ts
@@ -214,7 +214,7 @@ export class TransportEventBus extends EventBus implements EventBusEnabled {
         }
 
         const handler: MessageHandler<StompBusCommand> = this.requestStreamWithId(
-            `${config.host}:${config.port}${config.endpoint}`,
+            GeneralUtil.getFabricConnectionString(config.host, config.port, config.endpoint),
             BrokerConnectorChannel.connection,
             StompParser.generateStompBusCommand(StompClient.STOMP_CONNECT, '', '', config),
         );

--- a/src/fabric.api.ts
+++ b/src/fabric.api.ts
@@ -5,7 +5,7 @@
 
 import { UUID } from './bus/store/store.model';
 import { MessageFunction } from './bus.api';
-import { StoreStream } from './store.api';
+import { BusStore, StoreStream } from './store.api';
 import { APIRequest } from './core/model/request.model';
 import { Observable } from 'rxjs';
 import { APIResponse } from './core/model/response.model';
@@ -42,7 +42,7 @@ export interface FabricApi {
      * @param numRelays how many relays are being used? Defaults to 1.
      * @param connectHandler lambda to fire when the fabric is connected.
      * @param disconnectHandler  lambda to fire when the fabric is disconnected.
-     * @param autoReconnect if disconnected, want to auto-reconnect? defaults to false.
+     * @param autoReconnect if disconnected, want to auto-reconnect? defaults to true.
      */
     connect(
         connectHandler: MessageFunction<string>,
@@ -58,17 +58,30 @@ export interface FabricApi {
     /**
      * Disconnect from fabric.
      */
-    disconnect(connString: string): void;
+    disconnect(connString?: string): void;
 
     /**
      * returns current fabric connection status.
      */
-    isConnected(connString: string): boolean;
+    isConnected(connString?: string): boolean;
+
+    /**
+     * Get FabricConnectionState store for the given connection string.
+     *
+     * @param connString connection string of the target broker. if omitted, the bus will try to use the default
+     * connection string which is the one, and only one active broker connection in the session. connString needs to
+     * be provided always if more than one broker has been connected.
+     */
+    getConnectionStateStore(connString?: string): BusStore<FabricConnectionState>;
 
     /**
      * Grab a reference to state stream for connections.
+     *
+     * @param connString connection string of the target broker. if omitted, the bus will try to use the default
+     * connection string which is the one, and only one active broker connection in the session. connString needs to
+     * be provided always if more than one broker has been connected.
      */
-    whenConnectionStateChanges(connString: string): StoreStream<FabricConnectionState>;
+    whenConnectionStateChanges(connString?: string): StoreStream<FabricConnectionState>;
 
     /**
      * Generate a payload designed for fabric services, essentially a shortcut.
@@ -98,8 +111,12 @@ export interface FabricApi {
 
     /**
      * Get fabric version.
+     *
+     * @param connString connection string of the target broker. if omitted, the bus will try to use the default
+     * connection string which is the one, and only one active broker connection in the session. connString needs to
+     * be provided always if more than one broker has been connected.
      */
-    getFabricVersion(connString: string): Observable<string>;
+    getFabricVersion(connString?: string): Observable<string>;
 
     /**
      * Set sessionStorage key for access token.

--- a/src/util/bus.util.ts
+++ b/src/util/bus.util.ts
@@ -6,6 +6,7 @@
 import { TransportEventBus } from '../bus';
 import { EventBus } from '../bus.api';
 import { LogLevel } from '../log';
+import { GeneralUtil } from './util';
 
 /**
  * Test utility to encapsulate bus operations for test runs.
@@ -47,12 +48,15 @@ export class BusUtil {
     }
 
     /**
-     * Return connection string used to establish and manage one or more Fabric connections
+     * Return connection string used to establish and manage one or more Fabric connections.
+     *
      * @param {string} host hostname where Fabric backend is served
      * @param {number} port port where Fabric backend is served
      * @param {string} endpoint target endpoint
+     *
+     * @deprecated Use GeneralUtil.getFabricConnectionString()
      */
     public static getFabricConnectionString(host: string, port: number, endpoint: string) {
-        return `${host}:${port}${endpoint}`;
+        return GeneralUtil.getFabricConnectionString(host, port, endpoint);
     }
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -52,4 +52,17 @@ export class GeneralUtil {
         }
         return null;
     }
+
+    /**
+     * Return connection string used to establish and manage one or more Fabric connections
+     * @param {string} host hostname where Fabric backend is served
+     * @param {number} port port where Fabric backend is served
+     * @param {string} endpoint target endpoint
+     */
+    public static getFabricConnectionString(host: string, port: number, endpoint: string): string {
+        if (!host && (port === undefined || port === null)) {
+            return `${location.host}${endpoint}`;
+        }
+        return `${host}:${port}${endpoint}`;
+    }
 }


### PR DESCRIPTION
Patch from gitlab for v1.1

Patching over from internal gitlab.

* Bump up version from package.json and add relnote for 1.1.0
* Add comment to connString based on Dave's suggestion
* Clean up code to get connection string

Instead of constructing connection string multiple times in
various places throughout the code base having each invocation call the
singleton method that works the same across the board ensures easier
maintenance of the code. The reason the existing
`BusUtil.getFabricConnectionString()` was deprecated in this commit is
because the file the method is located (bus.util.ts) will cause a
circular references problem when referenced in other classes that are
one of the imports in the bus.util.ts. To prevent any further circular
references issues with this method that's used across many files,
I have moved the main function to util.ts and have the existing method
under bus.util.ts call it.

* Use connString as key to the FabricConnectionState store
* Move connection state store update into broker-connector
* Bump up version to 1.1.0
* Autodetect connString in presence of only one broker
* Update stomp client to usee FabricConnectionStore map