### PR TITLE
add forceError support

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -20,6 +20,16 @@
     "license": "BSD-2-Clause",
     "changelogHistory": [
         {
+            "date": "10/20/20",
+            "version": "1.2.2",
+            "notes": [
+                {
+                    "description": "Added forceError for AbstractAutoRestMock so users can force custom error messages during test",
+                    "review_uri": "https://gitlab.eng.vmware.com/bifrost/typescript/merge_requests/112"
+                }
+            ]
+        },
+        {
             "date": "10/9/20",
             "version": "1.2.1",
             "notes": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": false,
   "license": "BSD-2-Clause",
   "repository": "git@github.com:vmware/transport.git",

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -18,7 +18,7 @@ import { FabricApi } from './fabric.api';
 import { BrokerConnector } from './bridge';
 
 // current version
-const version = '1.2.1';
+const version = '1.2.2';
 
 export type ChannelName = string;
 export type SentFrom = string;

--- a/src/core/abstractions/abstract.autorestmock.spec.ts
+++ b/src/core/abstractions/abstract.autorestmock.spec.ts
@@ -40,6 +40,11 @@ class AutoRestTest extends AbstractAutoRestMock {
         this.handleRequest(HttpRequest.Get);
     }
 
+    public testHandleServiceForceError(): void {
+        this.forceError = 'error';
+        this.handleRequest(HttpRequest.Get);
+    }
+
     public testHandleServiceMustFail(): void {
         this.mustFail = true;
         this.handleRequest(HttpRequest.Get);
@@ -188,6 +193,14 @@ describe('Transport Abstract AutoRestMock [cores/abstractions/abstract.autorestm
         () => {
             test.testHandleServiceUnknownRequest();
             expect(bus.logger);
+        }
+    );
+
+    it('Check handleServiceRequest works for a custom forced error response',
+        () => {
+            spyOn(bus, 'sendErrorMessageWithId').and.callThrough();
+            test.testHandleServiceForceError();
+            expect(bus.sendErrorMessageWithId).toHaveBeenCalled();
         }
     );
 


### PR DESCRIPTION
Based on Akmal Suggestions i added forceError for AbstractAutoRestMock so users can force custom error messages during test

Signed-off-by: Josh Kim <kjosh@vmware.com>