### PR TITLE
whenConnectionStateChanges fires properly post fabric connection

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -20,6 +20,16 @@
     "license": "BSD-2-Clause",
     "changelogHistory": [
         {
+            "date": "11/18/20",
+            "version": "1.2.3",
+            "notes": [
+                {
+                    "description": "whenConnectionStateChanges now fires properly even after fabric connection was previously established",
+                    "review_uri": "https://gitlab.eng.vmware.com/bifrost/typescript/merge_requests/113"
+                }
+            ]
+        },
+        {
             "date": "10/20/20",
             "version": "1.2.2",
             "notes": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": false,
   "license": "BSD-2-Clause",
   "repository": "git@github.com:vmware/transport.git",

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -18,7 +18,7 @@ import { FabricApi } from './fabric.api';
 import { BrokerConnector } from './bridge';
 
 // current version
-const version = '1.2.2';
+const version = '1.2.3';
 
 export type ChannelName = string;
 export type SentFrom = string;


### PR DESCRIPTION
This MR fixes an issue with whenConnectionStateChanges() method to
trigger and execute its callback function even after fabric has been
connected beforehand.

Up until now, whenConnectionStateChanges() only fired when a fabric
connection was established after the method had been called.
This was leading to a sub optimal experience with the use of this
method where you needed to be aware of the order of fabric being
connected and this method being invoked. For example, in an Angular app
where it connects to the fabric during the APP_INITIALIZER stage,
navigating from a route to another route that is supposed to invoke the
whenConnectionStateChanges() method would not actually fire and leave
the component hanging indefinitely.

Signed-off-by: Josh Kim <kjosh@vmware.com>