### PR TITLE
Move on from CommonJS/AMD module

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -20,6 +20,15 @@
     "license": "BSD-2-Clause",
     "changelogHistory": [
         {
+            "date": "11/19/20",
+            "version": "1.2.4",
+            "notes": [
+                {
+                    "description": "Transport is now packaged under ES2015",
+                    "review_uri": "https://gitlab.eng.vmware.com/bifrost/typescript/merge_requests/114"
+                }
+            ]
+        },{
             "date": "11/18/20",
             "version": "1.2.3",
             "notes": [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,6 +40,9 @@ module.exports = function (config) {
         ],
         karmaTypescriptConfig: {
             tsconfig: "./tsconfig.json", // this will get rid of all compiler error messages
+            compilerOptions: {
+                module: 'commonjs'
+            },
             reports: {
                 "text-summary": "",
                 "html": "coverage/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -749,7 +749,6 @@
       "version": "6.10.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -760,14 +759,12 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
-      "dev": true
+      "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0="
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo=",
-      "dev": true
+      "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -847,8 +844,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/aproba/-/aproba-1.2.0.tgz?dl=https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
-      "dev": true
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "archy": {
       "version": "1.0.0",
@@ -916,8 +912,7 @@
     "array-filter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-      "dev": true
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
     "array-initial": {
       "version": "1.1.0",
@@ -1119,7 +1114,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
       "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
-      "dev": true,
       "requires": {
         "array-filter": "^1.0.0"
       }
@@ -1423,8 +1417,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1521,9 +1514,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
+      "version": "2.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
       "dev": true
     },
     "binaryextensions": {
@@ -1551,8 +1544,7 @@
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha1-qNCv1zJR7/u9X+OEp31zADwXpx8=",
-      "dev": true
+      "integrity": "sha1-qNCv1zJR7/u9X+OEp31zADwXpx8="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -1582,7 +1574,6 @@
       "version": "1.1.11",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1750,8 +1741,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
-      "dev": true
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -1781,7 +1771,6 @@
       "version": "12.0.4",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
       "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
-      "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
@@ -1803,14 +1792,12 @@
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
           "requires": {
             "yallist": "^3.0.2"
           }
@@ -1818,8 +1805,7 @@
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -1844,7 +1830,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
       "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.0"
@@ -1959,8 +1944,7 @@
     "chownr": {
       "version": "1.1.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha1-oY8eCyacimpdPIbrKYvrFMPde/Y=",
-      "dev": true
+      "integrity": "sha1-oY8eCyacimpdPIbrKYvrFMPde/Y="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -2280,14 +2264,12 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
-      "dev": true
+      "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI="
     },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/commondir/-/commondir-1.0.1.tgz?dl=https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "component-bind": {
       "version": "1.0.0",
@@ -2310,14 +2292,12 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -2328,14 +2308,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2350,7 +2328,6 @@
           "version": "1.1.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -2426,7 +2403,6 @@
       "version": "1.0.5",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/copy-concurrently/-/copy-concurrently-1.0.5.tgz?dl=https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
-      "dev": true,
       "requires": {
         "aproba": "^1.1.1",
         "fs-write-stream-atomic": "^1.0.8",
@@ -2440,7 +2416,6 @@
           "version": "2.7.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -2472,8 +2447,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -2581,8 +2555,7 @@
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cyclist/-/cyclist-1.0.1.tgz",
-      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
-      "dev": true
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "d": {
       "version": "1.0.1",
@@ -2658,8 +2631,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2703,7 +2675,6 @@
       "version": "1.1.3",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -2871,7 +2842,6 @@
       "version": "3.7.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -2883,7 +2853,6 @@
           "version": "1.4.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
-          "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -2891,14 +2860,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2913,7 +2880,6 @@
           "version": "1.1.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3108,7 +3074,6 @@
       "version": "0.1.7",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/errno/-/errno-0.1.7.tgz",
       "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
-      "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -3126,7 +3091,6 @@
       "version": "1.18.0-next.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
       "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -3145,14 +3109,12 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -3166,7 +3128,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3494,14 +3455,12 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz?dl=https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz?dl=https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "1.1.4",
@@ -3526,8 +3485,7 @@
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
-      "dev": true
+      "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -3578,7 +3536,6 @@
       "version": "2.1.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
-      "dev": true,
       "requires": {
         "commondir": "^1.0.1",
         "make-dir": "^2.0.0",
@@ -3638,16 +3595,15 @@
       "dev": true
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
+      "version": "2.0.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
       "dev": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
@@ -3656,14 +3612,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3678,7 +3632,6 @@
           "version": "1.1.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3709,8 +3662,7 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3731,7 +3683,6 @@
       "version": "2.3.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/from2/-/from2-2.3.0.tgz?dl=https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -3740,14 +3691,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3762,7 +3711,6 @@
           "version": "1.1.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3819,7 +3767,6 @@
       "version": "1.0.10",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz?dl=https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "iferr": "^0.1.5",
@@ -3830,16 +3777,14 @@
         "graceful-fs": {
           "version": "4.2.2",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/graceful-fs/-/graceful-fs-4.2.2.tgz",
-          "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI=",
-          "dev": true
+          "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI="
         }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz?dl=https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.1.3",
@@ -3851,8 +3796,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-      "dev": true
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -3863,14 +3807,12 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
-      "dev": true
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
     },
     "get-intrinsic": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
       "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -3880,8 +3822,7 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         }
       }
     },
@@ -3895,7 +3836,6 @@
       "version": "7.1.4",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-7.1.4.tgz",
       "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4945,7 +4885,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -4973,6 +4912,11 @@
           "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/isarray/-/isarray-2.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
@@ -5159,8 +5103,7 @@
     "iferr": {
       "version": "0.1.5",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/iferr/-/iferr-0.1.5.tgz?dl=https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-      "dev": true
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
     },
     "import-local": {
       "version": "2.0.0",
@@ -5175,8 +5118,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz?dl=https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indexof": {
       "version": "0.0.1",
@@ -5187,14 +5129,12 @@
     "infer-owner": {
       "version": "1.0.4",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
-      "dev": true
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc="
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5203,8 +5143,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "dev": true
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
       "version": "1.3.5",
@@ -5275,8 +5214,7 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -5302,8 +5240,7 @@
     "is-callable": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
-      "dev": true
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
     },
     "is-core-module": {
       "version": "2.1.0",
@@ -5337,8 +5274,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -5389,8 +5325,7 @@
     "is-generator-function": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
-      "dev": true
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
     },
     "is-glob": {
       "version": "3.1.0",
@@ -5419,8 +5354,7 @@
     "is-negative-zero": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
-      "dev": true
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
     },
     "is-number": {
       "version": "3.0.0",
@@ -5485,7 +5419,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
       "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       },
@@ -5493,8 +5426,7 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         }
       }
     },
@@ -5511,7 +5443,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       },
@@ -5519,8 +5450,7 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         }
       }
     },
@@ -5528,7 +5458,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
       "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.0",
         "es-abstract": "^1.17.4",
@@ -5540,7 +5469,6 @@
           "version": "1.17.7",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
           "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -5558,14 +5486,12 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -5605,14 +5531,12 @@
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "dev": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbinaryfile": {
       "version": "4.0.6",
@@ -5800,8 +5724,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz?dl=https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
-      "dev": true
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6603,7 +6526,6 @@
       "version": "3.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -6612,8 +6534,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         }
       }
     },
@@ -6824,7 +6745,6 @@
       "version": "2.1.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
-      "dev": true,
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -6833,14 +6753,12 @@
         "pify": {
           "version": "4.0.1",
           "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
-          "dev": true
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
         },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-          "dev": true
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
         }
       }
     },
@@ -7090,7 +7008,6 @@
       "version": "3.0.4",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -7098,14 +7015,12 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
-      "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
         "duplexify": "^3.4.2",
@@ -7123,7 +7038,6 @@
           "version": "1.4.1",
           "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.1.tgz?dl=https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
-          "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -7132,7 +7046,6 @@
           "version": "3.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/pump/-/pump-3.0.0.tgz",
           "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
-          "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -7165,7 +7078,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -7174,7 +7086,6 @@
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/move-concurrently/-/move-concurrently-1.0.1.tgz?dl=https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-      "dev": true,
       "requires": {
         "aproba": "^1.1.1",
         "copy-concurrently": "^1.0.0",
@@ -7188,7 +7099,6 @@
           "version": "2.7.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -7490,8 +7400,7 @@
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-is": {
       "version": "1.1.3",
@@ -7506,8 +7415,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
-      "dev": true
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -7584,7 +7492,6 @@
       "version": "1.4.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -7652,7 +7559,6 @@
       "version": "2.2.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -7661,7 +7567,6 @@
       "version": "3.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -7675,8 +7580,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-      "dev": true
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
     },
     "pad": {
       "version": "3.2.0",
@@ -7697,7 +7601,6 @@
       "version": "1.2.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parallel-transform/-/parallel-transform-1.2.0.tgz",
       "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
-      "dev": true,
       "requires": {
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
@@ -7707,14 +7610,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -7729,7 +7630,6 @@
           "version": "1.1.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -7836,8 +7736,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -7950,7 +7849,6 @@
       "version": "3.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
-      "dev": true,
       "requires": {
         "find-up": "^3.0.0"
       },
@@ -7959,7 +7857,6 @@
           "version": "3.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
           }
@@ -8068,8 +7965,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
-      "dev": true
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
     },
     "progress": {
       "version": "2.0.3",
@@ -8080,14 +7976,12 @@
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/promise-inflight/-/promise-inflight-1.0.1.tgz?dl=https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-      "dev": true
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -8107,7 +8001,6 @@
       "version": "2.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/pump/-/pump-2.0.1.tgz?dl=https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8117,7 +8010,6 @@
           "version": "1.4.1",
           "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.1.tgz?dl=https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
-          "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -8128,7 +8020,6 @@
       "version": "1.5.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/pumpify/-/pumpify-1.5.1.tgz?dl=https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
-      "dev": true,
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -8138,8 +8029,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
-      "dev": true
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "qjobs": {
       "version": "1.2.0",
@@ -8169,7 +8059,6 @@
       "version": "2.1.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -8227,7 +8116,6 @@
       "version": "1.1.14",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -8394,14 +8282,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
-      "dev": true
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
     },
     "requires-port": {
       "version": "1.0.0",
@@ -8474,7 +8360,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -8509,7 +8394,6 @@
       "version": "1.0.3",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/run-queue/-/run-queue-1.0.3.tgz?dl=https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
-      "dev": true,
       "requires": {
         "aproba": "^1.1.1"
       }
@@ -8535,8 +8419,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -8557,7 +8440,6 @@
       "version": "1.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
       "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
-      "dev": true,
       "requires": {
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",
@@ -8588,8 +8470,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -8955,8 +8836,7 @@
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
-      "dev": true
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ="
     },
     "source-map": {
       "version": "0.5.7",
@@ -9058,7 +8938,6 @@
       "version": "6.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/ssri/-/ssri-6.0.1.tgz",
       "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
-      "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
@@ -9203,7 +9082,6 @@
       "version": "1.2.3",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "stream-shift": "^1.0.0"
@@ -9213,7 +9091,6 @@
           "version": "1.4.1",
           "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.1.tgz?dl=https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
-          "dev": true,
           "requires": {
             "once": "^1.4.0"
           }
@@ -9252,8 +9129,7 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "string_decoder": {
           "version": "1.3.0",
@@ -9262,15 +9138,40 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.1",
+              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+              "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+              "dev": true
+            }
           }
+        },
+        "util": {
+          "version": "0.12.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/util/-/util-0.12.3.tgz",
+          "integrity": "sha1-lxuwKS0swMiS2rfGpdN8K+xweIg=",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "vm-browserify": {
+          "version": "1.1.2",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/vm-browserify/-/vm-browserify-1.1.2.tgz",
+          "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA="
         }
       }
     },
     "stream-shift": {
       "version": "1.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "stream-to-array": {
       "version": "2.3.0",
@@ -9347,7 +9248,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
       "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
@@ -9357,7 +9257,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
       "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.0-next.1"
@@ -9366,8 +9265,7 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -9563,7 +9461,6 @@
       "version": "2.0.5",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
-      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -9572,14 +9469,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -9594,7 +9489,6 @@
           "version": "1.1.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -9901,6 +9795,34 @@
           "requires": {
             "is-number": "^7.0.0"
           }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM="
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+          "requires": {
+            "decamelize": "^1.2.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+          "requires": {
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -10006,8 +9928,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedoc": {
       "version": "0.19.2",
@@ -10216,7 +10137,6 @@
       "version": "1.1.1",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
-      "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
       }
@@ -10225,7 +10145,6 @@
       "version": "2.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
-      "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
       }
@@ -10308,7 +10227,6 @@
       "version": "4.2.2",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz?dl=https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -10363,8 +10281,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -11145,6 +11062,28 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -11152,6 +11091,32 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
+          }
+        },
+        "terser": {
+          "version": "4.8.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "1.4.5",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+          "integrity": "sha1-oheu+uozDnNP+sthIOwfoxLWBAs=",
+          "requires": {
+            "cacache": "^12.0.2",
+            "find-cache-dir": "^2.1.0",
+            "is-wsl": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^4.0.0",
+            "source-map": "^0.6.1",
+            "terser": "^4.1.2",
+            "webpack-sources": "^1.4.0",
+            "worker-farm": "^1.7.0"
           }
         }
       }
@@ -11184,7 +11149,6 @@
       "version": "1.4.3",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-sources/-/webpack-sources-1.4.3.tgz",
       "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
-      "dev": true,
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
@@ -11193,8 +11157,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz?dl=https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         }
       }
     },
@@ -11327,14 +11290,12 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "which-typed-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
       "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.2",
         "es-abstract": "^1.17.5",
@@ -11348,7 +11309,6 @@
           "version": "1.17.7",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
           "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -11366,14 +11326,12 @@
         "has-symbols": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-          "dev": true
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -11387,7 +11345,6 @@
       "version": "1.7.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/worker-farm/-/worker-farm-1.7.0.tgz",
       "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
-      "dev": true,
       "requires": {
         "errno": "~0.1.7"
       }
@@ -11432,8 +11389,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "7.3.1",
@@ -11456,14 +11412,12 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
-      "dev": true
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
     },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/y18n/-/y18n-4.0.0.tgz?dl=https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
-      "dev": true
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "private": false,
   "license": "BSD-2-Clause",
   "repository": "git@github.com:vmware/transport.git",

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -18,7 +18,7 @@ import { FabricApi } from './fabric.api';
 import { BrokerConnector } from './bridge';
 
 // current version
-const version = '1.2.3';
+const version = '1.2.4';
 
 export type ChannelName = string;
 export type SentFrom = string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
-      "target": "es5",
+      "target": "es2015",
       "baseUrl": "./",
       "outDir": "./dist",
-      "module": "commonjs",
+      "module": "es2015",
       "moduleResolution": "node",
       "sourceMap": true,
       "emitDecoratorMetadata": true,
@@ -15,7 +15,7 @@
         "es5",
         "es6",
         "es7",
-        "es2015"
+        "es2020"
       ],
       "removeComments": false,
       "noImplicitAny": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
     mode: 'production',
@@ -10,24 +10,14 @@ module.exports = {
         new CleanWebpackPlugin()
     ],
     optimization: {
-        minimizer: [new UglifyJsPlugin({
-            parallel: true,
-            cache: true,
-            uglifyOptions: {
-                warnings: false,
-                parse: {},
-                compress: {
-                    sequences: true,
-                    dead_code: true,
-                    conditionals: true,
-                    booleans: true,
-                    unused: true,
-                    if_return: true,
-                    join_vars: true,
-                    passes: 5
-                },
+        minimize: true,
+        minimizer: [new TerserPlugin({
+            terserOptions: {
                 mangle: true,
-                mangle_props: true
+                module: true,
+                compress: {
+                    passes: 5
+                }
             }
         })]
     },


### PR DESCRIPTION
Transport has been built into a CommonJS/AMD module, however, as of
Angular 10 it started generating warnings on the library using
CommonJS/AMD packaging and its further hindrance on performance
optimization. This MR will change from the `commonjs` module to
`es6` which is now widely supported by most if not all major browsers.

Signed-off-by: Josh Kim <kjosh@vmware.com>