### PR TITLE
Remove unused lib causing security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8461,12 +8461,6 @@
         "sver-compat": "^1.5.0"
       }
     },
-    "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha1-z8IArvd7YAxH2pu4FJyUPnmML9s=",
-      "dev": true
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -10053,6 +10047,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
@@ -10062,32 +10057,8 @@
           "version": "0.6.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        }
-      }
-    },
-    "uglifyjs-webpack-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz",
-      "integrity": "sha1-51vIDn8ZN/cllUybTFoeln6p0Nc=",
-      "dev": true,
-      "requires": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.6.0",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz?dl=https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "tslint": "5.11.0",
     "typedoc": "^0.19.2",
     "typescript": "^3.9.7",
-    "uglifyjs-webpack-plugin": "^2.1.2",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
     "webpack-rxjs-externals": "^2.0.0",


### PR DESCRIPTION
The master repo currently has three security vulnerabilities that are tied to the second level devDependency imports that originate from `uglifyjs-webpack-plugin`. I have replaced the now defunct plugin with `terser-webpack-plugin`. This PR once merged will bring down the vulnerabilities to zero.