### PR TITLE
Add GitHub action workflows for CI/CD

### DIFF
--- a/.github/workflows/transport-build.yml
+++ b/.github/workflows/transport-build.yml
@@ -1,0 +1,54 @@
+name: Transport
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@vmw'
+      - run: npm install
+      - run: npm test
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@vmw'
+      - run: npm install
+      - run: npm run pre-publish
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-artifacts
+          path: dist
+  publish:
+    runs-on: ubuntu-20.04
+    needs:
+      - build
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@vmw'
+      - run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifacts
+          path: dist/
+      - run: ls -la

--- a/.github/workflows/transport-postmerge.yml
+++ b/.github/workflows/transport-postmerge.yml
@@ -1,8 +1,9 @@
-name: Transport
+name: Transport Post-merge pipeline
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
 
 jobs:
   test:
@@ -24,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@vmw'
       - run: npm install
@@ -33,22 +34,3 @@ jobs:
         with:
           name: build-artifacts
           path: dist
-  publish:
-    runs-on: ubuntu-20.04
-    needs:
-      - build
-    steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@vmw'
-      - run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Download build artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: build-artifacts
-          path: dist/
-      - run: ls -la

--- a/.github/workflows/transport-premerge.yml
+++ b/.github/workflows/transport-premerge.yml
@@ -1,0 +1,30 @@
+name: Transport Pre-merge pipeline
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@vmw'
+      - run: npm install
+      - run: npm test
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@vmw'
+      - run: npm install
+      - run: npm run pre-publish

--- a/.github/workflows/transport-release.yml
+++ b/.github/workflows/transport-release.yml
@@ -1,0 +1,43 @@
+name: Transport Release pipeline
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@vmw'
+      - run: npm install
+      - run: npm run pre-publish
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-artifacts
+          path: dist
+  publish:
+    runs-on: ubuntu-20.04
+    needs:
+      - build
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@vmw'
+      - run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifacts
+          path: dist/
+      - run: npm run publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 registry=https://registry.npmjs.org/
+always-auth=true


### PR DESCRIPTION
This PR adds three workflows to handle pre-merge (triggered by PRs), post-merge (by master commits) and release pipelines allowing us to push to Transport `npm` under `@vmw/transport`