### PR TITLE
Remove from .npmrc the auth token related placeholder

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
 registry=https://registry.npmjs.org/
-always-auth=true


### PR DESCRIPTION
If the environment variable is left unfilled it would break the npm
so it should be disabled at all times unless when it is time to publish
. In fact, the GitHub Actions will automatically pop this information
in during the publish stage.

Signed-off-by: Josh Kim <kjosh@vmware.com>