### PR TITLE
Fix UMD module and update README

### DIFF
--- a/.github/workflows/transport-postmerge.yml
+++ b/.github/workflows/transport-postmerge.yml
@@ -18,6 +18,13 @@ jobs:
           scope: '@vmw'
       - run: npm install
       - run: npm test
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/cobertura/coverage.xml
+          flags: unittests
+          fail_ci_if_error: true
+          verbose: true
   build:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/transport-premerge.yml
+++ b/.github/workflows/transport-premerge.yml
@@ -16,6 +16,13 @@ jobs:
           scope: '@vmw'
       - run: npm install
       - run: npm test
+      - uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/cobertura/coverage.xml
+          flags: unittests
+          fail_ci_if_error: true
+          verbose: true
   build:
     runs-on: ubuntu-20.04
     steps:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Transport - TypeScript
 
+![Transport Post-merge pipeline](https://github.com/vmware/transport-typescript/workflows/Transport%20Post-merge%20pipeline/badge.svg)
+[![codecov](https://codecov.io/gh/vmware/transport-typescript/branch/master/graph/badge.svg?token=93M5R55L38)](https://codecov.io/gh/vmware/transport-typescript)
+
 ## Overview
 ### What is Transport?
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,37 @@ Single Page Application states), to UI-to-backend or even backend-to-backend com
 ## Quick Start
 
 ```
-npm install @vmware/transport-typescript --save
+npm install @vmw/transport --save
 ```
 
-### Adding Transport to an Angular application
-Angular provides angular.json (for Angular 7+) and angular-cli.json (for Angular 4-5).
+### Adding Transport to your web application
+
+#### Option 1: ES6 module import (recommended)
+This is the recommended way to import Transport as it allows build management tool
+such as Webpack to treeshake unused exports of the library shaving off some bits in size.
+
+To import and initialize Transport, simply call `BusUtil.bootBus()` as follows:
+
+```typescript
+import { BusUtil } from '@vmw/transport/util/bus.util';
+
+// boot the event bus!
+BusUtil.bootBus();
+
+// once booted you can access the event bus instance from BusUtil.getInstance()
+console.log(BusUtil.getInstance());
+
+// you can destroy the event bus like this.
+BusUtil.destroy();
+
+// then boot the bus again with options to customize it. for example you can
+// initialize the bus with the log level set to warning, the boot message
+// enabled (second argument), and the dark console theme applied (third argument).
+BusUtil.bootBusWithOptions(LogLevel.Warn, false, true);
+```
+
+#### Option 2: Using UMD module in Angular
+Angular provides `angular.json` (for Angular 7+) and `angular-cli.json` (for Angular 4-5).
 
 In this file, there is a section defined as scripts. This section is where you provide third party scripts to be booted and loaded by your Angular application.
 
@@ -41,19 +67,45 @@ Configuring angular.json
 ```json
 ...
 "scripts": [
-   "node_modules/@vmware/transport/transport.umd.min.js"
+   "node_modules/@vmw/transport/transport.umd.min.js"
 ]
 ...
 ```
 Your application is ready to go, now you just need to boot transport
 
 Angular provides a src/main.ts file, which is essentially your initialization script, that you can use to Initialize the Bus.
+See Option 1 above for instructions on initializing the bus. 
+
+#### Option 3: UMD module import through HTML `<script>` tag
+Alternatively if you would like to use Transport in a simple setup, say an HTML
+with WebComponents in it, you can import the UMD version of the library via a `script` tag.
+Note that RxJS is the only prerequisite for Transport so make sure to import it first.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/rxjs@6.6.3/bundles/rxjs.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@vmw/transport@latest/transport.umd.min.js"></script>
+<script>
+   // boot the event bus!
+   transport.TransportEventBus.boot();
+
+   // once booted you can access the event bus instance at window.AppEventBus.
+   console.log(AppEventBus);
+
+   // destroy the event bus.
+   transport.TransportEventBus.destroy();
+
+   // boot the event bus with options.
+   transport.TransportEventBus.bootWithOptions(1, false, true);
+
+</script>
+```
+
 
 ### Importing Transport in your code
 The main interface you will need is EventBus. It provides access to the most common methods.
 
 ```
-import { EventBus } from '@vmware/transport-typescript';
+import { EventBus } from '@vmw/transport';
 ```
 
 ### Hello World

--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -10,6 +10,7 @@
     "peerDependencies": {
         "rxjs": "^6.4.0"
     },
+    "main": "./transport.umd.min.js",
     //@exclude
     "scripts": {
         "prepare": "echo 'Error: Please run \"npm run prepare\" on the parent project' && exit 1"
@@ -20,7 +21,16 @@
     "license": "BSD-2-Clause",
     "changelogHistory": [
         {
-            "date": "2/11/20",
+            "date": "2/11/21",
+            "version": "1.2.7",
+            "notes": [
+                {
+                    "description": "Update README for accurate getting started and fix UMD module",
+                    "review_uri": "https://github.com/vmware/transport-typescript/pull/31"
+                }
+            ]
+        },{
+            "date": "2/11/21",
             "version": "1.2.6",
             "notes": [
                 {
@@ -29,7 +39,7 @@
                 }
             ]
         },{
-            "date": "2/10/20",
+            "date": "2/10/21",
             "version": "1.2.5",
             "notes": [
                 {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -45,7 +45,12 @@ module.exports = function (config) {
             },
             reports: {
                 "text-summary": "",
-                "html": "coverage/"
+                "html": "coverage/",
+                "cobertura": {
+                    "directory": "coverage",
+                    "subdirectory": "cobertura",
+                    "filename": "coverage.xml"
+                }
             },
             exclude: ['proxyTestApp/**/*.ts','chatClientApp/**/*.ts', './node_modules/**/*.d.ts']
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "private": false,
   "license": "BSD-2-Clause",
   "repository": "git@github.com:vmware/transport-typescript.git",

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -18,7 +18,7 @@ import { FabricApi } from './fabric.api';
 import { BrokerConnector } from './bridge';
 
 // current version
-const version = '1.2.6';
+const version = '1.2.7';
 
 export type ChannelName = string;
 export type SentFrom = string;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,8 +46,7 @@ module.exports = {
         extensions: ['.ts', '.js']
     },
     externals: {
-        'rxjs': 'rxjs',
-        'rxjs/operators': 'rxjs/operators'
+        'rxjs': 'rxjs'
     }
 };
 


### PR DESCRIPTION
UMD module was not usable because of rxjs/operators being not able
to be reached inside the Transport UMD module. This PR builds the
UMD module together with rxjs/operators to fix the issue, at the
cost of a slight increase of bundle size which now sits at 100KB.
Also README got updated with accurate getting started information for
three different ways to import and use the library.

Signed-off-by: Josh Kim <kjosh@vmware.com>