### PR TITLE
Bump ssri to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8591,9 +8591,9 @@
       "dev": true
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "requires": {
         "figgy-pudding": "^3.5.1"
       }


### PR DESCRIPTION
References:

https://github.com/webpack-contrib/terser-webpack-plugin/issues/388
https://github.com/npm/ssri/issues/18

Signed-off-by: Josh Kim <kjosh@vmware.com>