### PR TITLE
Fix ReadableStream issue in Safari

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -21,6 +21,15 @@
     "license": "BSD-2-Clause",
     "changelogHistory": [
         {
+            "date": "5/10/21",
+            "version": "1.2.8",
+            "notes": [
+                {
+                    "description": "Fix ReadableStream issue in Safari",
+                    "review_uri": "https://github.com/vmware/transport-typescript/pull/37"
+                }
+            ]
+        },{
             "date": "2/11/21",
             "version": "1.2.7",
             "notes": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4820,9 +4820,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-escaper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2214,7 +2214,7 @@
     },
     "component-inherit": {
       "version": "0.0.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/component-inherit/-/component-inherit-0.0.3.tgz?dl=https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
@@ -2858,6 +2858,36 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "engine.io-client": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "~1.3.0",
+        "component-inherit": "0.0.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.2.0",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.6",
+        "parseuri": "0.0.6",
+        "ws": "~7.4.2",
+        "xmlhttprequest-ssl": "~1.6.2",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "engine.io-parser": {
@@ -4691,7 +4721,7 @@
     },
     "has-cors": {
       "version": "1.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/has-cors/-/has-cors-1.1.0.tgz?dl=https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
@@ -7332,6 +7362,18 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
+    "parseqs": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
+      "dev": true
+    },
+    "parseuri": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
+      "dev": true
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8326,42 +8368,6 @@
             "debug": "~4.1.0",
             "engine.io-parser": "~2.2.0",
             "ws": "~7.4.2"
-          }
-        },
-        "engine.io-client": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.0.tgz",
-          "integrity": "sha512-12wPRfMrugVw/DNyJk34GQ5vIVArEcVMXWugQGGuw2XxUSztFNmJggZmv8IZlLyEdnpO1QB9LkcjeWewO2vxtA==",
-          "dev": true,
-          "requires": {
-            "component-emitter": "~1.3.0",
-            "component-inherit": "0.0.3",
-            "debug": "~3.1.0",
-            "engine.io-parser": "~2.2.0",
-            "has-cors": "1.1.0",
-            "indexof": "0.0.1",
-            "parseqs": "0.0.6",
-            "parseuri": "0.0.6",
-            "ws": "~7.4.2",
-            "xmlhttprequest-ssl": "~1.5.4",
-            "yeast": "0.1.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            }
           }
         },
         "isarray": {
@@ -10915,10 +10921,16 @@
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "ws": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
+      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+      "dev": true
+    },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz?dl=https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
+      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
       "dev": true
     },
     "xregexp": {
@@ -10999,7 +11011,7 @@
     },
     "yeast": {
       "version": "0.1.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/yeast/-/yeast-0.1.2.tgz?dl=https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -375,6 +375,24 @@
       "integrity": "sha1-M2utwb7sudrMOL6izzKt9ieoQho=",
       "dev": true
     },
+    "@types/component-emitter": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==",
+      "dev": true
+    },
+    "@types/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
+      "dev": true
+    },
+    "@types/cors": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
+      "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.38",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/@types/estree/-/estree-0.0.38.tgz?dl=https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
@@ -713,12 +731,6 @@
       "integrity": "sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==",
       "dev": true
     },
-    "after": {
-      "version": "0.8.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/after/-/after-0.8.2.tgz?dl=https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
-      "dev": true
-    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.10.2.tgz",
@@ -789,9 +801,9 @@
       "dev": true
     },
     "anymatch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -961,12 +973,6 @@
       "version": "0.3.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true
-    },
-    "arraybuffer.slice": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
     "asn1.js": {
@@ -1316,12 +1322,6 @@
         "now-and-later": "^2.0.0"
       }
     },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/backo2/-/backo2-1.0.2.tgz?dl=https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1427,12 +1427,6 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
-    },
-    "blob": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
-      "dev": true
     },
     "bluebird": {
       "version": "3.5.5",
@@ -1753,14 +1747,14 @@
       }
     },
     "chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1787,9 +1781,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -2126,22 +2120,10 @@
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/commondir/-/commondir-1.0.1.tgz?dl=https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/component-bind/-/component-bind-1.0.0.tgz?dl=https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
-      "dev": true
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "concat-map": {
@@ -2248,6 +2230,12 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/copy-concurrently/-/copy-concurrently-1.0.5.tgz?dl=https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -2297,6 +2285,16 @@
       "version": "1.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-ecdh": {
       "version": "4.0.3",
@@ -2786,47 +2784,45 @@
         "once": "^1.4.0"
       }
     },
-    "engine.io-client": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
-      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
+    "engine.io": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
+      "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
       "dev": true,
       "requires": {
-        "component-emitter": "~1.3.0",
-        "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.2.0",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.6.2",
-        "yeast": "0.1.2"
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~4.0.0",
+        "ws": "~7.4.2"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
     "engine.io-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
-      "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
+      "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
       "dev": true,
       "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.4",
-        "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
+        "base64-arraybuffer": "0.1.4"
       }
     },
     "enhanced-resolve": {
@@ -2977,6 +2973,12 @@
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -3423,9 +3425,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
+      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
       "dev": true
     },
     "for-in": {
@@ -3519,14 +3521,6 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        }
       }
     },
     "fs-mkdirp-stream": {
@@ -3571,9 +3565,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
@@ -4617,34 +4611,6 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "has-binary2": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-      "dev": true,
-      "requires": {
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/isarray/-/isarray-2.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
-        }
-      }
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-      "dev": true
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
@@ -4823,12 +4789,6 @@
       "version": "0.1.4",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz?dl=https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -5243,9 +5203,9 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isbinaryfile": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
-      "integrity": "sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
+      "integrity": "sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==",
       "dev": true
     },
     "isexe": {
@@ -5473,9 +5433,9 @@
       "dev": true
     },
     "karma": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-5.2.3.tgz",
-      "integrity": "sha512-tHdyFADhVVPBorIKCX8A37iLHxc6RBRphkSoQ+MLKdAtFn1k97tD8WUGi1KlEtDZKL3hui0qhsY9HXUfSNDYPQ==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.2.tgz",
+      "integrity": "sha512-fo4Wt0S99/8vylZMxNj4cBFyOBBnC1bewZ0QOlePij/2SZVWxqbyLeIddY13q6URa2EpLRW8ixvFRUMjkmo1bw==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
@@ -5496,11 +5456,11 @@
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
-        "socket.io": "^2.3.0",
+        "socket.io": "^3.1.0",
         "source-map": "^0.6.1",
         "tmp": "0.2.1",
-        "ua-parser-js": "0.7.22",
-        "yargs": "^15.3.1"
+        "ua-parser-js": "^0.7.23",
+        "yargs": "^16.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5527,21 +5487,15 @@
             "fill-range": "^7.0.1"
           }
         },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
         "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
+            "wrap-ansi": "^7.0.0"
           }
         },
         "color-convert": {
@@ -5580,20 +5534,10 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
         "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -5603,12 +5547,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
@@ -5622,34 +5560,10 @@
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
         "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
           "dev": true
         },
         "rimraf": {
@@ -5668,9 +5582,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -5697,9 +5611,9 @@
           }
         },
         "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -5708,39 +5622,31 @@
           }
         },
         "y18n": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-          "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
           "dev": true
         },
         "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
           "dev": true,
           "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
             "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
         }
       }
     },
@@ -6286,9 +6192,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -6572,18 +6478,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.47.0"
       }
     },
     "minimalistic-assert": {
@@ -7270,18 +7176,6 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
-    "parseqs": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-      "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-      "dev": true
-    },
-    "parseuri": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-      "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-      "dev": true
-    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7715,9 +7609,9 @@
       },
       "dependencies": {
         "picomatch": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+          "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
           "dev": true
         }
       }
@@ -8236,164 +8130,64 @@
       }
     },
     "socket.io": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.4.1.tgz",
-      "integrity": "sha512-Si18v0mMXGAqLqCVpTxBa8MGqriHGQh8ccEOhmsmNS3thNCGBwO8WGrwMibANsWtQQ5NStdZwHqZR3naJVFc3w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
+      "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
       "dev": true,
       "requires": {
-        "debug": "~4.1.0",
-        "engine.io": "~3.5.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.4.0",
-        "socket.io-parser": "~3.4.0"
+        "@types/cookie": "^0.4.0",
+        "@types/cors": "^2.8.8",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.1",
+        "engine.io": "~4.1.0",
+        "socket.io-adapter": "~2.1.0",
+        "socket.io-parser": "~4.0.3"
       },
       "dependencies": {
-        "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-          "dev": true
-        },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
-        },
-        "engine.io": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.5.0.tgz",
-          "integrity": "sha512-21HlvPUKaitDGE4GXNtQ7PLP0Sz4aWLddMPw2VTyFz1FVZqu/kZsJUO8WNpKuE/OCL7nkfRaOui2ZCJloGznGA==",
-          "dev": true,
-          "requires": {
-            "accepts": "~1.3.4",
-            "base64id": "2.0.0",
-            "cookie": "~0.4.1",
-            "debug": "~4.1.0",
-            "engine.io-parser": "~2.2.0",
-            "ws": "~7.4.2"
-          }
-        },
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-          "dev": true
         },
         "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        },
-        "parseqs": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-          "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-          "dev": true
-        },
-        "parseuri": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-          "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-          "dev": true
-        },
-        "socket.io-client": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
-          "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
-          "dev": true,
-          "requires": {
-            "backo2": "1.0.2",
-            "component-bind": "1.0.0",
-            "component-emitter": "~1.3.0",
-            "debug": "~3.1.0",
-            "engine.io-client": "~3.5.0",
-            "has-binary2": "~1.0.2",
-            "indexof": "0.0.1",
-            "parseqs": "0.0.6",
-            "parseuri": "0.0.6",
-            "socket.io-parser": "~3.3.0",
-            "to-array": "0.1.4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            },
-            "socket.io-parser": {
-              "version": "3.3.2",
-              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
-              "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
-              "dev": true,
-              "requires": {
-                "component-emitter": "~1.3.0",
-                "debug": "~3.1.0",
-                "isarray": "2.0.1"
-              }
-            }
-          }
-        },
-        "ws": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-          "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
     },
     "socket.io-adapter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
-      "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
       "dev": true
     },
     "socket.io-parser": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
-      "integrity": "sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "~4.1.0",
-        "isarray": "2.0.1"
+        "@types/component-emitter": "^1.2.10",
+        "component-emitter": "~1.3.0",
+        "debug": "~4.3.1"
       },
       "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
-        },
-        "isarray": {
-          "version": "2.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/isarray/-/isarray-2.0.1.tgz?dl=https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -8719,9 +8513,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -9078,12 +8872,6 @@
         "is-absolute": "^1.0.0",
         "is-negated-glob": "^1.0.0"
       }
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/to-array/-/to-array-0.1.4.tgz?dl=https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
-      "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -9516,9 +9304,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.22",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
       "dev": true
     },
     "uglify-js": {
@@ -9761,6 +9549,12 @@
       "version": "3.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/value-or-function/-/value-or-function-3.0.0.tgz",
       "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "vinyl-fs": {
@@ -10835,12 +10629,6 @@
       "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
       "dev": true
     },
-    "xmlhttprequest-ssl": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
-      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
-      "dev": true
-    },
     "xregexp": {
       "version": "3.1.0",
       "resolved": "https://build-artifactory.eng.vmware.com/artifactory/api/npm/npm/xregexp/-/xregexp-3.1.0.tgz",
@@ -10916,12 +10704,6 @@
           "dev": true
         }
       }
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
-      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4660,9 +4660,9 @@
       }
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,12 +64,6 @@
             "minimist": "^1.2.5"
           }
         },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -156,14 +150,6 @@
         "@babel/traverse": "^7.12.1",
         "@babel/types": "^7.12.1",
         "lodash": "^4.17.19"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -319,12 +305,6 @@
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -344,12 +324,6 @@
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        },
         "to-fast-properties": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -1136,14 +1110,6 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "babel-generator": {
@@ -1160,14 +1126,6 @@
         "lodash": "^4.17.4",
         "source-map": "^0.5.7",
         "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "babel-helper-hoist-variables": {
@@ -1273,14 +1231,6 @@
         "lodash": "^4.17.4",
         "mkdirp": "^0.5.1",
         "source-map-support": "^0.4.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "babel-runtime": {
@@ -1312,14 +1262,6 @@
         "babel-types": "^6.26.0",
         "babylon": "^6.18.0",
         "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "babel-traverse": {
@@ -1337,14 +1279,6 @@
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
         "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "babel-types": {
@@ -1357,14 +1291,6 @@
         "esutils": "^2.0.2",
         "lodash": "^4.17.4",
         "to-fast-properties": "^1.0.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        }
       }
     },
     "babylon": {
@@ -4265,12 +4191,6 @@
         "preprocess": "^3.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        },
         "map-stream": {
           "version": "0.1.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/map-stream/-/map-stream-0.1.0.tgz",
@@ -5711,12 +5631,6 @@
             "p-locate": "^4.1.0"
           }
         },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        },
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
@@ -6031,12 +5945,6 @@
           "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
-        "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-          "dev": true
-        },
         "log4js": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
@@ -6329,9 +6237,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.clone": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": false,
   "license": "BSD-2-Clause",
   "repository": "git@github.com:vmware/transport-typescript.git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-typescript": "^5.0.1",
     "intl": "1.2.5",
     "jasmine-core": "^3.6.0",
-    "karma": "^5.2.3",
+    "karma": "^6.3.2",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^2.0.3",
     "karma-jasmine": "^2.0.1",

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -18,7 +18,7 @@ import { FabricApi } from './fabric.api';
 import { BrokerConnector } from './bridge';
 
 // current version
-const version = '1.2.7';
+const version = '1.2.8';
 
 export type ChannelName = string;
 export type SentFrom = string;

--- a/src/core/services/rest/http.client.ts
+++ b/src/core/services/rest/http.client.ts
@@ -4,9 +4,9 @@
  */
 
 export interface HttpClient {
-    get(request: Request, successHandler: Function, failureHandler: Function): void;
-    post(request: Request, successHandler: Function, failureHandler: Function): void;
-    put(request: Request, successHandler: Function, failureHandler: Function): void;
-    patch(request: Request, successHandler: Function, failureHandler: Function): void;
-    delete(request: Request, successHandler: Function, failureHandler: Function): void;
+    get(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void;
+    post(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void;
+    put(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void;
+    patch(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void;
+    delete(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void;
 }

--- a/src/core/services/rest/httpclient.mock.ts
+++ b/src/core/services/rest/httpclient.mock.ts
@@ -11,28 +11,28 @@ export class MockHttpClient implements HttpClient {
     public mustFail = false;
     public errCode = 200;
 
-    delete(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    delete(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
-    get(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    get(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
-    patch(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    patch(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
-    post(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    post(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
-    put(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    put(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
     private httpOperation(
-        request: Request,
+        uri: string, requestInit: RequestInit,
         successHandler: Function,
         errorHandler: Function
     ) {
@@ -47,7 +47,7 @@ export class MockHttpClient implements HttpClient {
             err['message'] = 'Fake Error';
             errorHandler(err);
         } else {
-            successHandler(`${request.method} called`);
+            successHandler(`${requestInit.method} called`);
         }
     }
 }

--- a/src/core/services/rest/rest.service.ts
+++ b/src/core/services/rest/rest.service.ts
@@ -187,45 +187,30 @@ export class RestService extends AbstractCore implements EventBusEnabled, Fabric
 
         // generate fetch headers, init and request objects.
         const requestHeadersObject = new Headers(requestHeaders);
-        const requestInit = this.generateRequestInitObject(restObject, requestHeadersObject);
-        let httpRequest;
+        const requestInit: RequestInit = this.generateRequestInitObject(restObject, requestHeadersObject);
 
-        // try to create fetch request.
-        try {
-
-            const uri: string = this.globalBaseUri + restObject.uri;
-            this.log.debug(`Rest Service: Preparing Fetch Request for URI: ${uri}`, this.getName());
-            httpRequest = new Request(uri, requestInit);
-
-
-        } catch (e) {
-            this.log.error(`Rest Service: Cannot create request: ${e}`, this.getName());
-            this.handleError(
-                new RestError('Invalid HTTP request.', RestErrorType.UnknownMethod, restObject.uri),
-                restObject,
-                args);
-            return;
-        }
+        const uri: string = this.globalBaseUri + restObject.uri;
+        this.log.debug(`Rest Service: Preparing Fetch Request for URI: ${uri}`, this.getName());
 
         switch (restObject.request) {
             case HttpRequest.Get:
-                this.httpClient.get(httpRequest, successHandler, errorHandler);
+                this.httpClient.get(uri, requestInit, successHandler, errorHandler);
                 break;
 
             case HttpRequest.Post:
-                this.httpClient.post(httpRequest, successHandler, errorHandler);
+                this.httpClient.post(uri, requestInit, successHandler, errorHandler);
                 break;
 
             case HttpRequest.Patch:
-                this.httpClient.patch(httpRequest, successHandler, errorHandler);
+                this.httpClient.patch(uri, requestInit, successHandler, errorHandler);
                 break;
 
             case HttpRequest.Put:
-                this.httpClient.put(httpRequest, successHandler, errorHandler);
+                this.httpClient.put(uri, requestInit, successHandler, errorHandler);
                 break;
 
             case HttpRequest.Delete:
-                this.httpClient.delete(httpRequest, successHandler, errorHandler);
+                this.httpClient.delete(uri, requestInit, successHandler, errorHandler);
                 break;
 
             default:
@@ -238,7 +223,7 @@ export class RestService extends AbstractCore implements EventBusEnabled, Fabric
         }
     }
 
-    private generateRequestInitObject(restObject: RestObject, headers: Headers): any {
+    private generateRequestInitObject(restObject: RestObject, headers: Headers): RequestInit {
 
         let requestInit: any = {
             method: restObject.request,

--- a/src/core/services/rest/transport.httpclient.spec.ts
+++ b/src/core/services/rest/transport.httpclient.spec.ts
@@ -38,10 +38,10 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make valid GET fetch request',
         (done) => {
-            fetchMock.get('http://appfabric.vmware.com/', 'ok');
-
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Get});
-            client.get(request,
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.get(url, 'ok');
+            client.get(url, 
+                {method: HttpRequest.Get},
                 (responseObject: any) => {
                     expect(responseObject).toEqual('ok');
                     done();
@@ -53,10 +53,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make GET fetch request that handles server error',
         (done) => {
-            fetchMock.get('http://appfabric.vmware.com/', 500 );
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.get(url, 500 );
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Get});
-            client.get(request,
+            client.get(url, 
+                {method: HttpRequest.Get},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 500: Internal Server Error');
@@ -65,12 +66,14 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
             );
         }
     );
+
     it('Can make bad GET fetch request',
         (done) => {
+            const url = 'http://appfabric.vmware.com';
             fetchMock.get('http://appfabric.vmware.com/', 400);
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Get});
-            client.get(request,
+            client.get(url, 
+                {method: HttpRequest.Get},
                 () => {
                 },
                 (failureObject: GeneralError) => {
@@ -83,11 +86,12 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make valid POST fetch request',
         (done) => {
-            fetchMock.post('http://appfabric.vmware.com/', 'ok');
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.post(url, 'ok');
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Post, body: 'hi!'});
-            client.post(request,
-                (responseObject: any) => {
+            client.post(url,
+                    {method: HttpRequest.Post, body: 'hi!'},
+                    (responseObject: any) => {
                     expect(responseObject).toEqual('ok');
                     done();
                 },
@@ -98,10 +102,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make POST fetch request that handles server error',
         (done) => {
-            fetchMock.post('http://appfabric.vmware.com/', 500);
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.post(url, 500);
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Post, body: 'hi!'});
-            client.post(request,
+            client.post(url,
+                {method: HttpRequest.Post, body: 'hi!'},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 500: Internal Server Error');
@@ -113,10 +118,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make bad POST fetch request',
         (done) => {
-            fetchMock.post('http://appfabric.vmware.com/', 400 );
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.post(url, 400 );
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Post, body: 'hi!'});
-            client.post(request,
+            client.post(url,
+                {method: HttpRequest.Post, body: 'hi!'},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 400: Bad Request');
@@ -128,10 +134,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make valid PATCH fetch request',
         (done) => {
-            fetchMock.patch('http://appfabric.vmware.com/', 'ok');
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.patch(url, 'ok');
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Patch, body: 'hi!'});
-            client.patch(request,
+            client.patch(url,
+                {method: HttpRequest.Patch, body: 'hi!'},
                 (responseObject: any) => {
                     expect(responseObject).toEqual('ok');
                     done();
@@ -143,10 +150,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make PATCH fetch request that handles server error',
         (done) => {
-            fetchMock.patch('http://appfabric.vmware.com/', 500);
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.patch(url, 500);
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Patch, body: 'hi!'});
-            client.patch(request,
+            client.patch(url,
+                {method: HttpRequest.Patch, body: 'hi!'},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 500: Internal Server Error');
@@ -155,12 +163,14 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
             );
         }
     );
+
     it('Can make bad PATCH fetch request',
         (done) => {
-            fetchMock.patch('http://appfabric.vmware.com/', 400 );
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.patch(url, 400 );
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Patch, body: 'hi!'});
-            client.patch(request,
+            client.patch(url,
+                {method: HttpRequest.Patch, body: 'hi!'},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 400: Bad Request');
@@ -172,10 +182,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make valid PUT fetch request',
         (done) => {
-            fetchMock.put('http://appfabric.vmware.com/', 'ok');
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.put(url, 'ok');
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Put, body: 'hi!'});
-            client.put(request,
+            client.put(url,
+                {method: HttpRequest.Put, body: 'hi!'},
                 (responseObject: any) => {
                     expect(responseObject).toEqual('ok');
                     done();
@@ -187,10 +198,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make PUT fetch request that handles server error',
         (done) => {
-            fetchMock.put('http://appfabric.vmware.com/', 500);
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.put(url, 500);
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Put, body: 'hi!'});
-            client.put(request,
+            client.put(url,
+                {method: HttpRequest.Put, body: 'hi!'},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 500: Internal Server Error');
@@ -199,12 +211,14 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
             );
         }
     );
+
     it('Can make bad PUT fetch request',
         (done) => {
-            fetchMock.put('http://appfabric.vmware.com/', 400 );
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.put(url, 400 );
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Put, body: 'hi!'});
-            client.put(request,
+            client.put(url,
+                {method: HttpRequest.Put, body: 'hi!'},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 400: Bad Request');
@@ -216,10 +230,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make valid DELETE fetch request',
         (done) => {
-            fetchMock.delete('http://appfabric.vmware.com/', 'ok');
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.delete(url, 'ok');
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Delete});
-            client.delete(request,
+            client.delete(url,
+                {method: HttpRequest.Delete},
                 (responseObject: any) => {
                     expect(responseObject).toEqual('ok');
                     done();
@@ -231,10 +246,11 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can make DELETE fetch request that handles server error',
         (done) => {
-            fetchMock.delete('http://appfabric.vmware.com/', 500);
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.delete(url, 500);
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Delete});
-            client.delete(request,
+            client.delete(url,
+                {method: HttpRequest.Delete},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 500: Internal Server Error');
@@ -243,12 +259,14 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
             );
         }
     );
+
     it('Can make bad DELETE fetch request',
         (done) => {
-            fetchMock.delete('http://appfabric.vmware.com/', 400 );
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.delete(url, 400 );
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Delete});
-            client.delete(request,
+            client.delete(url,
+                {method: HttpRequest.Delete},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 400: Bad Request');
@@ -260,13 +278,14 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can handle error message object (mainly from ss-base consumers)',
         (done) => {
-            fetchMock.get('http://appfabric.vmware.com/', {
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.get(url, {
                 status: 500,
                 body: JSON.stringify({message: 'oh dear.'})
             });
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Get});
-            client.get(request,
+            client.get(url,
+                {method: HttpRequest.Get},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 500: Internal Server Error -  oh dear.');
@@ -278,13 +297,14 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can handle error messages array object (mainly from ss-base consumers)',
         (done) => {
-            fetchMock.get('http://appfabric.vmware.com/', {
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.get(url, {
                 status: 500,
                 body: JSON.stringify({error_messages: ['oh', 'deary', 'me']})
             });
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Get});
-            client.get(request,
+            client.get(url,
+                {method: HttpRequest.Get},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.message).toEqual('HTTP Error 500: Internal Server Error -  oh, deary, me');
@@ -296,13 +316,14 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can handle error code (mainly from ss-base consumers)',
         (done) => {
-            fetchMock.get('http://appfabric.vmware.com/', {
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.get(url, {
                 status: 500,
                 body: JSON.stringify({error_code: 500})
             });
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Get});
-            client.get(request,
+            client.get(url,
+                {method: HttpRequest.Get},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.status).toEqual(500);
@@ -315,13 +336,14 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
 
     it('Can handle error status (mainly from ss-base consumers)',
         (done) => {
-            fetchMock.get('http://appfabric.vmware.com/', {
+            const url = 'http://appfabric.vmware.com';
+            fetchMock.get(url, {
                 status: 500,
                 body: JSON.stringify({status: 500})
             });
 
-            let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Get});
-            client.get(request,
+            client.get(url,
+                {method: HttpRequest.Get},
                 () => { },
                 (failureObject: GeneralError) => {
                     expect(failureObject.status).toEqual(500);
@@ -332,12 +354,13 @@ describe('Transport HTTP Client [cores/services/rest/transport.httpclient]', () 
     );
 
     it('Can handle TypeError', (done) => {
-        fetchMock.get('http://appfabric.vmware.com/', {
+        const url = 'http://appfabric.vmware.com';
+        fetchMock.get(url, {
             throws: new TypeError('network error')
         });
 
-        let request = new Request('http://appfabric.vmware.com', {method: HttpRequest.Get});
-        client.get(request,
+        client.get(url,
+            {method: HttpRequest.Get},
             () => { },
             (failureObject: GeneralError) => {
             console.log(failureObject.message);

--- a/src/core/services/rest/transport.httpclient.ts
+++ b/src/core/services/rest/transport.httpclient.ts
@@ -8,35 +8,36 @@ import { GeneralError } from '../../model/error.model';
 
 export class TransportHttpclient implements HttpClient {
 
-    delete(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    delete(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
-    get(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    get(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
-    patch(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    patch(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
-    post(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    post(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
-    put(request: Request, successHandler: Function, failureHandler: Function): void {
-        this.httpOperation(request, successHandler, failureHandler);
+    put(uri: string, requestInit: RequestInit, successHandler: Function, failureHandler: Function): void {
+        this.httpOperation(uri, requestInit, successHandler, failureHandler);
     }
 
     private httpOperation(
-        request: Request,
+        uri: string, 
+        requestInit: RequestInit,
         successHandler: Function,
         errorHandler: Function
     ) {
 
         // use magic fetch!
         fetch(
-            request
+            uri, requestInit
         ).then(
             (response: Response) => {
                 if (response.ok) {


### PR DESCRIPTION
`new Request` wraps the request body in `ReadableStream`, which is not supported by Safari.
Pass the url & RequestInit directly instead using the `Request` interface. 