### PR TITLE
Added missing connecting state to connection state enum.

### DIFF
--- a/src/fabric.api.ts
+++ b/src/fabric.api.ts
@@ -13,6 +13,7 @@ import { APIResponse } from './core/model/response.model';
 export enum FabricConnectionState {
     Connected = 'connected',
     Disconnected = 'disconnected',
+    Connecting = 'connecting',
     Failed = 'failed'
 }
 


### PR DESCRIPTION
Important for any applications using these same states in their applications. This is going to be used in our docs, so we need it for all application use. Non breaking change, zero impact on the rest of the stack.

Signed-off-by: Dave Shanley <dshanley@vmware.com>