### PR TITLE
fix: Remove hard-coded /user prefix for broker queues

### DIFF
--- a/src/bridge/broker-connector.ts
+++ b/src/bridge/broker-connector.ts
@@ -315,7 +315,7 @@ export class BrokerConnector implements EventBusEnabled {
                     const subscriptionId = this.generateSubscriptionId(session.id, cleanedChannel);
                     const brokerPrefix = galacticConfig.isPrivate ? config.queueLocation : config.topicLocation;
                     const destination =
-                        StompParser.generateGalacticDesintation(brokerPrefix, cleanedChannel, galacticConfig.isPrivate);
+                        StompParser.generateGalacticDesintation(brokerPrefix, cleanedChannel);
                     const subscription =
                         StompParser.generateStompBrokerSubscriptionRequest(
                             session.id, destination, subscriptionId, galacticConfig.isPrivate, brokerPrefix
@@ -358,7 +358,7 @@ export class BrokerConnector implements EventBusEnabled {
                 const brokerPrefix = this._privateChannels.get(channel)[sessionBrokerIdentity] ?
                     config.queueLocation : config.topicLocation;
                 const destination =
-                    StompParser.generateGalacticDesintation(brokerPrefix, cleanedChannel, isPrivateChannel);
+                    StompParser.generateGalacticDesintation(brokerPrefix, cleanedChannel);
                 const subscription = StompParser.generateStompBrokerSubscriptionRequest(
                         session.id, destination, subscriptionId, isPrivateChannel, brokerPrefix);
 
@@ -741,7 +741,7 @@ export class BrokerConnector implements EventBusEnabled {
                 );
 
             const channel: string = StompParser.convertTopicOrQueueToChannel(
-                data.destination, data.brokerPrefix, data.isQueue);
+                data.destination, data.brokerPrefix);
 
             const chan: Observable<Message> =
                 this.bus.api.getRequestChannel(channel, this.getName());
@@ -764,8 +764,7 @@ export class BrokerConnector implements EventBusEnabled {
                     let respChan =
                         StompParser.convertSubscriptionToChannel(
                             data.destination,
-                            data.isQueue ? session.config.queueLocation : session.config.topicLocation,
-                            data.isQueue);
+                            data.isQueue ? session.config.queueLocation : session.config.topicLocation);
                     let payload = JSON.parse(msg.body);
 
                     const respChannelObject = this.bus.api.getChannelObject(respChan);
@@ -820,8 +819,7 @@ export class BrokerConnector implements EventBusEnabled {
 
             // let the bus know.
             this.sendBusCommandResponseRaw(message, BrokerConnectorChannel.subscription, true);
-            const channel: string = StompParser.convertTopicOrQueueToChannel(
-                data.destination, data.brokerPrefix, data.isQueue);
+            const channel: string = StompParser.convertTopicOrQueueToChannel(data.destination, data.brokerPrefix);
 
             const sub: Subscription = session.getGalacticSubscription(channel);
 

--- a/src/bridge/stomp.parser.spec.ts
+++ b/src/bridge/stomp.parser.spec.ts
@@ -248,12 +248,12 @@ describe('Stomp Parser [stomp.parser]', () => {
 
             // public channel
             const subA = StompParser.convertSubscriptionToChannel(
-                'puppykitty/', 'kitty', false);
+                'puppykitty/', 'kitty');
             expect(subA).toEqual('puppy');
 
             // private channel
             const subB = StompParser.convertSubscriptionToChannel(
-                '/userpuppy/kitty', 'puppy', true);
+                'puppy/kitty', 'puppy');
             expect(subB).toEqual('kitty');
 
         }

--- a/src/bridge/stomp.parser.ts
+++ b/src/bridge/stomp.parser.ts
@@ -202,24 +202,22 @@ export class StompParser {
     }
 
     // create galactic topic/queue detination
-    public static generateGalacticDesintation(dest: string, channel: string, isQueue: boolean): string {
-        return (isQueue ? '/user' : '') + dest + '/' + channel;
+    public static generateGalacticDesintation(dest: string, channel: string): string {
+        return dest + '/' + channel;
     }
 
     // convert destination back into a channel
     public static convertSubscriptionToChannel(subscription: string,
-                                               topicOrQueueDesintation: string,
-                                               isQueue: boolean): string {
+                                               topicOrQueueDesintation: string): string {
         return subscription.replace(
-            (isQueue ? '/user' + topicOrQueueDesintation : topicOrQueueDesintation) + '/',
+            topicOrQueueDesintation + '/',
             '');
     }
 
     // convert topic/queue back into a channel
     public static convertTopicOrQueueToChannel(subscription: string,
-                                               brokerPrefix: string,
-                                               isQueue: boolean): string {
+                                               brokerPrefix: string): string {
         return subscription.replace(
-            isQueue ? '/user' + brokerPrefix + '/' : brokerPrefix + '/', '').trim();
+            brokerPrefix + '/', '').trim();
     }
 }


### PR DESCRIPTION
The current behavior of Fabric module, when subscribing to a queue destination, is to prefix the destination with hardcoded `/user` so even though the Fabric is configured to use a queue prefix of `/queue` any destination gets prepended with `/user` which results in something like `/user/queue/destination` when a STOMP frame is sent to the broker for subscription.

This is a remnant of the initial private channel support work in Transport when the majority of development and testing work was done against the Spring Boot's STOMP broker. Now that Plank defaults to NOT using the `/user` prefix, this default behavior is actually breaking the out-of-the-box user experience hence removing the prefix in this PR.

Signed-off-by: Josh Kim <kjosh@vmware.com>