### PR TITLE
fix: Schedule bus callbacks in autogen code through NgZone

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -29,6 +29,16 @@
     "license": "BSD-2-Clause",
     "changelogHistory": [
         {
+            "date": "8/31/21",
+            "version": "1.3.3",
+            "notes": [
+                {
+                    "description": "Schedule bus callbacks in autogen code through NgZone",
+                    "review_uri": "https://github.com/vmware/transport-typescript/pull/58"
+                }
+            ]
+        },
+        {
             "date": "8/25/21",
             "version": "1.3.2",
             "notes": [

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -21,7 +21,7 @@ import { BrokerConnector } from './bridge';
 export declare type NgZoneRef = any;
 
 // current version
-const version = '1.3.2';
+const version = '1.3.3';
 
 export type ChannelName = string;
 export type SentFrom = string;
@@ -856,6 +856,11 @@ export interface EventBusLowApi {
      * Get uuid of the bus.;
      */
     getId(): UUID;
+
+    /**
+     * Get handle of NgZone
+     */
+    ngZone(): NgZoneRef;
 
     /**
      * Set up Subject and subscribe to it that will fire as messages are emitted to trigger Angular change detection.

--- a/src/bus/bus.lowlevel.ts
+++ b/src/bus/bus.lowlevel.ts
@@ -6,7 +6,7 @@
 
 import {
     ChannelBrokerMapping,
-    ChannelName, EventBus, EventBusLowApi, MessageFunction, MessageHandler, MessageResponder, MessageType,
+    ChannelName, EventBus, EventBusLowApi, MessageFunction, MessageHandler, MessageResponder, MessageType, NgZoneRef,
     SentFrom
 } from '../bus.api';
 import { Channel } from './model/channel.model';
@@ -37,12 +37,17 @@ export class EventBusLowLevelApiImpl implements EventBusLowApi {
     private internalChannelMap: Map<string, Channel>;
     private id: UUID;
     private ngViewRefreshSubject?: Subject<void>;
+    private _ngZone: NgZoneRef;
 
     public ngViewRefreshSubscription?: Subscription;
     public loggerInstance: Logger;
 
     public getId(): UUID {
         return this.id;
+    }
+
+    public ngZone(): NgZoneRef {
+        return this._ngZone;
     }
 
     constructor(private eventBusRef: EventBus, channelMap: Map<string, Channel>, logger: Logger) {
@@ -358,6 +363,9 @@ export class EventBusLowLevelApiImpl implements EventBusLowApi {
     setUpNgViewRefreshScheduler(): void {
         // kill any existing subscription
         this.ngViewRefreshSubscription?.unsubscribe();
+
+        // grab and store handle of angular zone
+        this._ngZone = this.eventBusRef.zoneRef;
 
         // create a Subject that triggers Angular change detection when a new message arrives. to prevent
         // suffocating CPU resource from too many cycles, debounce the incoming messages by NGZONE_TRIGGER_DEBOUNCE_THRESHOLD milliseconds.

--- a/src/core/services/rest/rest.operations.ts
+++ b/src/core/services/rest/rest.operations.ts
@@ -29,6 +29,7 @@ export interface RestOperation {
 export class RestOperations extends AbstractCore {
 
     protected static _instance: RestOperations;
+    protected readonly execContext: any;
 
     /**
      * Kill instance of service.
@@ -46,6 +47,7 @@ export class RestOperations extends AbstractCore {
     constructor() {
         super();
         this.id = GeneralUtil.genUUID();
+        this.execContext = this.bus.api.ngZone() ?? { run: (fn: () => void) => fn() };
     }
 
     public setGlobalHttpHeaders(headers: any, from: SentFrom) {
@@ -205,7 +207,7 @@ export class RestOperations extends AbstractCore {
                         , from);
 
                 }
-                operation.successHandler(responseObject);
+                this.execContext.run(() => operation.successHandler(responseObject));
             }
         );
 
@@ -217,7 +219,7 @@ export class RestOperations extends AbstractCore {
                         error = error.payload;
                     }
 
-                    operation.errorHandler(error);
+                    this.execContext.run(() => operation.errorHandler(error));
                 }
             );
         }


### PR DESCRIPTION
This PR fixes an issue that was identified while testing Transport 1.3.2 locally on VMware Cloud UI. The autogenerated code utilizes autogenerated bus channels, from and to which messages are transmitted outside of Angular Zone based on the changes made in 1.3.2. At some point after calling an API using the autogenerated service adapter method, results are returned back to the client which is running in Angular Zone, as a callback.

However, the API success callback was still running outside of Angular Zone, so any tasks that would schedule a macro/micro task were running side-by-side with Angular's change detection system instead of being scheduled properly next to the earlier tasks in the queue, ultimately causing the unstable UI state.


Signed-off-by: Josh Kim <kjosh@vmware.com>