### PR TITLE
fix: UMD included in bundle after treeshaking

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -10,7 +10,6 @@
     "peerDependencies": {
         "rxjs": "^6.4.0"
     },
-    "main": "./transport.umd.min.js",
     //@exclude
     "scripts": {
         "prepare": "echo 'Error: Please run \"npm run prepare\" on the parent project' && exit 1"
@@ -28,6 +27,16 @@
     ],
     "license": "BSD-2-Clause",
     "changelogHistory": [
+        {
+            "date": "9/3/21",
+            "version": "1.3.4",
+            "notes": [
+                {
+                    "description": "Fix tree-shaking issue",
+                    "review_uri": "https://github.com/vmware/transport-typescript/pull/59"
+                }
+            ]
+        },
         {
             "date": "8/31/21",
             "version": "1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vmw/transport",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "private": false,
     "license": "BSD-2-Clause",
     "repository": "git@github.com:vmware/transport-typescript.git",

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -21,7 +21,7 @@ import { BrokerConnector } from './bridge';
 export declare type NgZoneRef = any;
 
 // current version
-const version = '1.3.3';
+const version = '1.3.4';
 
 export type ChannelName = string;
 export type SentFrom = string;


### PR DESCRIPTION
Up until 1.3.3 when importing Transport as an ES6 module the UMD module
file would still be included as part of the application bundle as can
be seen by the breakdown from webpack-bundle-analyzer. This PR fixes it
by removing the `main` entry from the package.json which will result in
about 100kB of reduced bundle size.

**Before fix:**

![before-fix](https://user-images.githubusercontent.com/3834071/132059001-e5018c39-2da2-4570-96b9-b06430f03a8e.png)

**After fix:**

![after-fix](https://user-images.githubusercontent.com/3834071/132059025-53dcbd15-4fad-4236-b34b-568f9891f0a3.png)


Signed-off-by: Josh Kim <jsk9260@gmail.com>