### PR TITLE
vendor: Upgrade rxjs to 7 and typescript to 4

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -8,7 +8,8 @@
         "url": "git@github.com:vmware/transport-typescript.git"
     },
     "peerDependencies": {
-        "rxjs": "^6.4.0"
+        "rxjs": "6 - 7",
+        "typescript": ">= 4.2"
     },
     //@exclude
     "scripts": {
@@ -27,6 +28,16 @@
     ],
     "license": "BSD-2-Clause",
     "changelogHistory": [
+        {
+            "date": "9/8/21",
+            "version": "1.3.5",
+            "notes": [
+                {
+                    "description": "Upgrade rxjs to 7 and typescript to 4",
+                    "review_uri": "https://github.com/vmware/transport-typescript/pull/60"
+                }
+            ]
+        },
         {
             "date": "9/3/21",
             "version": "1.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vmw/transport",
-  "version": "1.3.3",
+  "version": "1.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1013,12 +1013,6 @@
         "async-done": "^1.2.2"
       }
     },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
-    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -1823,15 +1817,6 @@
                 "remove-trailing-separator": "^1.0.1"
               }
             }
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
           }
         }
       }
@@ -3477,6 +3462,27 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
     "glob-stream": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
@@ -3496,12 +3502,24 @@
       },
       "dependencies": {
         "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^4.0.1"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
           }
         }
       }
@@ -5445,9 +5463,9 @@
       }
     },
     "marked": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.7.tgz",
-      "integrity": "sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.3.tgz",
+      "integrity": "sha512-4oIDhVSQ2s+xNCfek9OnZgCQR/WykGCom02JzIIvi4Pme+MIwPYqvGVW8CQWOXeoZu0TtVB6pTxIuoLm+dKqDA==",
       "dev": true
     },
     "matchdep": {
@@ -6263,6 +6281,12 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true
     },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -6880,11 +6904,18 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
       }
     },
     "safe-buffer": {
@@ -7018,21 +7049,10 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
     "shiki": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.6.tgz",
-      "integrity": "sha512-h2y5Uq9QEWsEmi97n+BOdPOVxkOUdVunl+jVIzU9EqJ6/QbIX+U6F7TsrWZQ2xqwPgvvQaC9r7/zeegi1b48dQ==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.10.tgz",
+      "integrity": "sha512-xeM7Oc6hY+6iW5O/T5hor8ul7mEprzyl5y4r5zthEHToQNw7MIhREMgU3r2gKDB0NaMLNrkcEQagudCdzE13Lg==",
       "dev": true,
       "requires": {
         "json5": "^2.2.0",
@@ -8018,7 +8038,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tslint": {
       "version": "5.11.0",
@@ -8086,52 +8107,19 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.20.37",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.37.tgz",
-      "integrity": "sha512-9+qDhdc4X00qTNOtii6QX2z7ndAeWVOso7w3MPSoSJdXlVhpwPfm1yEp4ooKuWA9fiQILR8FKkyjmeqa13hBbw==",
+      "version": "0.21.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
+      "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
       "dev": true,
       "requires": {
-        "colors": "^1.4.0",
-        "fs-extra": "^9.1.0",
+        "glob": "^7.1.7",
         "handlebars": "^4.7.7",
-        "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "~2.0.3",
+        "marked": "^3.0.2",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "shelljs": "^0.8.4",
-        "shiki": "^0.9.3",
+        "shiki": "^0.9.8",
         "typedoc-default-themes": "^0.12.10"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        }
       }
     },
     "typedoc-default-themes": {
@@ -8141,9 +8129,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "ua-parser-js": {
@@ -8153,9 +8141,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.1.tgz",
-      "integrity": "sha512-JhS3hmcVaXlp/xSo3PKY5R0JqKs5M3IV+exdLHW99qKvKivPO4Z8qbej6mte17SOPqAOVMjt/XGgWacnFSzM3g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.2.tgz",
+      "integrity": "sha512-rtPMlmcO4agTUfz10CbgJ1k6UAoXM2gWb3GoMPPZB/+/Ackf8lNWk11K4rYi2D0apgoFRLtQOZhb+/iGNJq26A==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@vmw/transport",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "private": false,
     "license": "BSD-2-Clause",
     "repository": "git@github.com:vmware/transport-typescript.git",
     "dependencies": {
         "karma-jasmine-html-reporter": "^1.5.4",
-        "rxjs": "^6.6.3"
+        "rxjs": "^7.3.0"
     },
     "devDependencies": {
         "@types/fetch-mock": "^7.3.3",
@@ -45,8 +45,8 @@
         "systemjs-builder": "^0.16.13",
         "ts-loader": "^6.2.2",
         "tslint": "5.11.0",
-        "typedoc": "^0.20.24",
-        "typescript": "^3.9.7",
+        "typedoc": "^0.21.9",
+        "typescript": "^4.4.2",
         "webpack": "^4.44.2",
         "webpack-cli": "^3.3.12",
         "webpack-rxjs-externals": "^2.0.0",

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -21,7 +21,7 @@ import { BrokerConnector } from './bridge';
 export declare type NgZoneRef = any;
 
 // current version
-const version = '1.3.4';
+const version = '1.3.5';
 
 export type ChannelName = string;
 export type SentFrom = string;

--- a/src/bus/bus.lowlevel.ts
+++ b/src/bus/bus.lowlevel.ts
@@ -499,7 +499,7 @@ export class EventBusLowLevelApiImpl implements EventBusLowApi {
     private sendSubscribedMonitorMessage(uuid: UUID, channelName: ChannelName, from?: SentFrom): void {
         this.monitorStream.send(
             new Message().request(
-                new MonitorObject().build(MonitorType.MonitorObserverSubscribedChannel, channelName, name,
+                new MonitorObject().build(MonitorType.MonitorObserverSubscribedChannel, channelName, from,
                     {id: uuid, from: from})
             )
         );
@@ -508,7 +508,7 @@ export class EventBusLowLevelApiImpl implements EventBusLowApi {
     private sendUnsubscribedMonitorMessage(uuid: UUID, channelName: ChannelName, from?: SentFrom): void {
         this.monitorStream.send(
             new Message().request(
-                new MonitorObject().build(MonitorType.MonitorObserverUnsubscribedChannel, channelName, name,
+                new MonitorObject().build(MonitorType.MonitorObserverUnsubscribedChannel, channelName, from,
                     {id: uuid, from: from})
             )
         );


### PR DESCRIPTION
This PR upgrades Transport's `rxjs` and `typescript` dependencies to 7 and 4 respectively so Transport can be used alongside Angular 12 and its peer dependencies. Transport will remain functional with RxJS v6 but `typescript` will need to be upgraded to 4.2 or above unless you consume the UMD version. 

Signed-off-by: Josh Kim <kjosh@vmware.com>