### PR TITLE
fix: Guard against double-free of galacticChannel objects

### DIFF
--- a/build/npm/transport.json
+++ b/build/npm/transport.json
@@ -29,6 +29,16 @@
     "license": "BSD-2-Clause",
     "changelogHistory": [
         {
+            "date": "5/6/22",
+            "version": "1.3.6",
+            "notes": [
+                {
+                    "description": "Guard against race condition from process sleep/wake that corrupt galacticChannels map state",
+                    "review_uri": "https://github.com/vmware/transport-typescript/pull/61"
+                }
+            ]
+        },
+        {
             "date": "9/8/21",
             "version": "1.3.5",
             "notes": [

--- a/src/bus.api.ts
+++ b/src/bus.api.ts
@@ -21,7 +21,7 @@ import { BrokerConnector } from './bridge';
 export declare type NgZoneRef = any;
 
 // current version
-const version = '1.3.5';
+const version = '1.3.6';
 
 export type ChannelName = string;
 export type SentFrom = string;


### PR DESCRIPTION
This PR fixes a bug that happens in a very unlikely scenario where there could be a "double free" condition
of the internal galactic channel object. This object usually is stored in a Map and is deleted when the last broker
session has disconnected. The "double free", to be exact, means that this object's internal counter is being
decremented which is triggered by a WebSocket disconnection event, but the object already had been
cleaned up by `this.closeGalacticChannel() that was triggered by a bus message. The consequence of the
double free is a JavaScript equivalent of NullPointerException. This issue is extremely hard to reproduce 
with only limited stacktrace information through screenshots.  But I suspect that it has to do with the
browser tab process being put to sleep after a long idle, and a resultant race condition that may have led to
the above chain of actions. A fix implemented in this PR prevents the double-free by protecting the
decrement instruction against a situation where the galactic channel object had been destroyed.

Signed-off-by: Josh Kim <kjosh@vmware.com>